### PR TITLE
Permission denied when saving key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && \
 # Create non-root user for security
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 
+# Create data directory and set ownership BEFORE switching to appuser
+RUN mkdir -p /data && chown -R appuser:appuser /data
+
 COPY --from=builder /usr/src/app/target/release/atlas-transparency-log /usr/local/bin/atlas-transparency-log
 RUN chmod +x /usr/local/bin/atlas-transparency-log
 


### PR DESCRIPTION
The container was failing to save the key with the following error:
```bash
thread 'main' panicked at src/main.rs:608:61:
Failed to save key: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This happened because the /data directory was created after switching to the non-root appuser, resulting in incorrect ownership and write permissions.